### PR TITLE
Fix underline text translation issue

### DIFF
--- a/javascripts/discourse/api-initializers/api-setup.js
+++ b/javascripts/discourse/api-initializers/api-setup.js
@@ -13,7 +13,6 @@ export default apiInitializer("0.11.1", (api) => {
 
   // Localization setup - keep only the button titles in translations
   I18n.translations[currentLocale].js.underline_button_title = settings.underline_button;
-  I18n.translations[currentLocale].js.underline_text = settings.underline_text;
   // Toolbar Button Definitions
   api.onToolbarCreate((toolbar) => {
     const buttons = [

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,4 +1,4 @@
 en:
   js:
     underline_button_title: "Underline"
-    underline_text: settings.underline_text
+    underline_text: "Example Text"


### PR DESCRIPTION
Update code to return "Example Text" instead of "[en.composer.underline_text]".

* **locales/en.yml**
  - Update `underline_text` to "Example Text" directly.
* **javascripts/discourse/api-initializers/api-setup.js**
  - Remove the line setting `I18n.translations[currentLocale].js.underline_text` to `settings.underline_text`.

