### PR TITLE
Fix EmberJS translation issue

### DIFF
--- a/javascripts/discourse/api-initializers/api-setup.js
+++ b/javascripts/discourse/api-initializers/api-setup.js
@@ -4,7 +4,7 @@ import I18n from "I18n";
 
 // Helper function to get raw text without translation
 function getRawText(text) {
-  return text.replace(/\[.*?\]/g, '');
+  return text;
 }
 
 export default apiInitializer("0.11.1", (api) => {
@@ -22,7 +22,7 @@ export default apiInitializer("0.11.1", (api) => {
         icon: "underline",
         shortcut: "U",
         title: "underline_button_title",
-        perform: (e) => e.applySurround("[u]", "[/u]", "Example Text"),
+        perform: (e) => e.applySurround("[u]", "[/u]", settings.underline_text),
       },
     ];
 


### PR DESCRIPTION
Update `getRawText` function and `perform` function in `api-setup.js` to return text without translation brackets and use `underline_text` setting.

* Modify `getRawText` function to return text without removing translation brackets.
* Update `perform` function of `underline_button` to use `underline_text` setting instead of hardcoded "Example Text".

