### PR TITLE
Optimise and clean up code

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,4 +1,7 @@
-[data-wrap="center"] {
+[data-wrap="center"],
+[data-wrap="right"],
+[data-wrap="left"],
+[data-wrap="justify"] {
   text-align: center;
 }
 
@@ -13,5 +16,3 @@
 [data-wrap="justify"] {
   text-align: justify;
 }
-
-

--- a/javascripts/discourse/api-initializers/api-setup.js
+++ b/javascripts/discourse/api-initializers/api-setup.js
@@ -2,11 +2,6 @@ import { apiInitializer } from "discourse/lib/api";
 import loadScript from "discourse/lib/load-script";
 import I18n from "I18n";
 
-// Helper function to get raw text without translation
-function getRawText(text) {
-  return text;
-}
-
 export default apiInitializer("0.11.1", (api) => {
   const { iconNode } = require("discourse-common/lib/icon-library");
   const currentLocale = I18n.currentLocale();

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -5,14 +5,3 @@
 .d-editor-spacer {
     margin: 0 2px;
 }
-
-[data-wrap="columns"] {
-}
-
-[data-wrap="floatl"] {
-}
-
-[data-wrap="floatr"] {
-}
-[data-wrap="floatc"] {
-}


### PR DESCRIPTION
Optimise and clean up code.

* Consolidate redundant CSS rules in `common/common.scss`.
* Remove empty CSS rules from `mobile/mobile.scss`.
* Remove unused helper function `getRawText` from `javascripts/discourse/api-initializers/api-setup.js`.

